### PR TITLE
Pass through user kwargs to rasterio.features.rasterize

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -13,6 +13,7 @@ Enhancements
 - new ``open_mf_wrf_dataset`` function
 - new ``deacc`` method added to DataArrayAccessors
 - new ``Map.transform()`` method to make over-plotting easier (experimental)
+- new **rasterize_kws** argument added to ``Grid.region_of_interest()`` to pass additional kwargs to  ``rasterio.features.rasterize``
 
 Bug fixes
 ~~~~~~~~~

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -13,7 +13,7 @@ Enhancements
 - new ``open_mf_wrf_dataset`` function
 - new ``deacc`` method added to DataArrayAccessors
 - new ``Map.transform()`` method to make over-plotting easier (experimental)
-- new **rasterize_kws** argument added to ``Grid.region_of_interest()`` to pass additional kwargs to  ``rasterio.features.rasterize``
+- new **all_touched** argument added to ``Grid.region_of_interest()`` to pass through to  ``rasterio.features.rasterize``, tweaking how grid cells are included in the region of interest
 
 Bug fixes
 ~~~~~~~~~

--- a/salem/gis.py
+++ b/salem/gis.py
@@ -233,7 +233,7 @@ class Grid(object):
         self._x0 = np.float(x0)
         self._y0 = np.float(y0)
         self._order = order
-        
+
         # Check for pixel ref
         self._pixel_ref = kwargs['pixel_ref'].lower()
         if self._pixel_ref not in ['corner', 'center']:
@@ -312,7 +312,7 @@ class Grid(object):
     def center_grid(self):
         """``salem.Grid`` instance representing the grid in center coordinates.
         """
-        
+
         if self.pixel_ref == 'center':
             return self
         else:
@@ -322,7 +322,7 @@ class Grid(object):
                         proj=self.proj, pixel_ref='center')
             args[self.order + '_corner'] = x0y0
             return Grid(**args)
-        
+
     @lazy_property
     def corner_grid(self):
         """``salem.Grid`` instance representing the grid in corner coordinates.
@@ -896,7 +896,6 @@ class Grid(object):
         return np.ma.masked_invalid(out_data)
 
     def region_of_interest(self, shape=None, geometry=None, grid=None,
-                           corners=None, crs=wgs84, roi=None):
                            corners=None, crs=wgs84, roi=None,
                            rasterize_kws={}):
         """Computes a region of interest (ROI).

--- a/salem/gis.py
+++ b/salem/gis.py
@@ -897,6 +897,8 @@ class Grid(object):
 
     def region_of_interest(self, shape=None, geometry=None, grid=None,
                            corners=None, crs=wgs84, roi=None):
+                           corners=None, crs=wgs84, roi=None,
+                           rasterize_kws={}):
         """Computes a region of interest (ROI).
 
         A ROI is simply a mask of the same size as the grid.
@@ -917,6 +919,9 @@ class Grid(object):
         roi : ndarray
             add the new region_of_interest to a previous one (useful for
             multiple geometries for example)
+        rasterize_kws : dict
+            dictionary of additional keyword arguments to pass to
+            rasterio.features.rasterize
         """
 
         # Initial mask
@@ -924,6 +929,10 @@ class Grid(object):
             mask = np.array(roi, dtype=np.int16)
         else:
             mask = np.zeros((self.ny, self.nx), dtype=np.int16)
+
+        # Add mask to rasterize keyword arguments, overriding anything the user
+        # inadvertently added
+        rasterize_kws['out'] = mask
 
         # Several cases
         if shape is not None:
@@ -938,7 +947,8 @@ class Grid(object):
                                         inplace=inplace)
             import rasterio
             with rasterio.Env():
-                mask = rasterio.features.rasterize(shape.geometry, out=mask)
+                mask = rasterio.features.rasterize(shape.geometry,
+                                                   **rasterize_kws)
         if geometry is not None:
             import rasterio
             # corner grid is needed for rasterio

--- a/salem/sio.py
+++ b/salem/sio.py
@@ -451,7 +451,7 @@ class _XarrayAccessorBase(object):
 
     def roi(self, ds=None, **kwargs):
         """roi(self, shape=None, geometry=None, grid=None, corners=None,
-               crs=wgs84, roi=None, rasterize_kws={})
+               crs=wgs84, roi=None, all_touched=False)
 
         Make a region of interest (ROI) for the dataset.
 
@@ -474,9 +474,10 @@ class _XarrayAccessorBase(object):
             coordinate reference system of the geometry and corners
         roi : ndarray
             if you have a mask ready, you can give it here
-        rasterize_kws : dict
-            dictionary of additional keyword arguments to pass to
-            rasterio.features.rasterize
+        all_touched : boolean
+            pass-through argument for rasterio.features.rasterize, indicating
+            that all grid cells which are  clipped by the shapefile defining
+            the region of interest should be included (default=False)
         """
 
         if ds is not None:

--- a/salem/sio.py
+++ b/salem/sio.py
@@ -451,7 +451,7 @@ class _XarrayAccessorBase(object):
 
     def roi(self, ds=None, **kwargs):
         """roi(self, shape=None, geometry=None, grid=None, corners=None,
-               crs=wgs84, roi=None)
+               crs=wgs84, roi=None, rasterize_kws={})
 
         Make a region of interest (ROI) for the dataset.
 
@@ -474,6 +474,9 @@ class _XarrayAccessorBase(object):
             coordinate reference system of the geometry and corners
         roi : ndarray
             if you have a mask ready, you can give it here
+        rasterize_kws : dict
+            dictionary of additional keyword arguments to pass to
+            rasterio.features.rasterize
         """
 
         if ds is not None:
@@ -686,7 +689,7 @@ class DataArrayAccessor(_XarrayAccessorBase):
         Parameters
         ----------
         as_rate: bool
-          set to false if you don't want units per hour, 
+          set to false if you don't want units per hour,
           but units per given data timestep
         """
 


### PR DESCRIPTION
This is a simple code change that lets you pass kwargs through to [`rasterio.features.rasterize`](https://mapbox.github.io/rasterio/api/rasterio.features.html#rasterio.features.rasterize). In particular, I wanted to use the  **all_touched** kwarg to include cells clipped by my shapefile/regions.

A simple example using the test ozone data I previously posted an issue about. By default, this is the sort of plot we get, using a custom function which plots our map:

``` python
us_subset = ozone_subset.salem.roi(shape=usa)
x = us_subset.where(~us_subset.isnull(), drop=True)
ax = plot_map(x)

import numpy as np
xx, yy = np.meshgrid(x.lon, x.lat)
ax.scatter(xx, yy, marker='x', color='k', s=3)
```

![image](https://cloud.githubusercontent.com/assets/4992424/21723301/ebc3b946-d3fd-11e6-978c-beef17c4ff73.png)

Notice how the coasts are clipped and we miss grid cells covering them, particularly Florida, Texas, and California.

Repeating, but passing the **all_touched** kwarg:

``` python
us_subset = ozone_subset.salem.roi(shape=usa, rasterize_kws=dict(all_touched=True))
x = us_subset.where(~us_subset.isnull(), drop=True)
ax = plot_map(x)

import numpy as np
xx, yy = np.meshgrid(x.lon, x.lat)
ax.scatter(xx, yy, marker='x', color='k', s=3)
```

![image](https://cloud.githubusercontent.com/assets/4992424/21723357/16d09320-d3fe-11e6-9b46-9788145b97e4.png)

[`rasterize`](https://mapbox.github.io/rasterio/api/rasterio.features.html#rasterio.features.rasterize) doesn't really expose too many arguments, so this may be superfluous - it might be simpler just to directly add the **all_touched** argument inside `Grid.region_of_interest`,