### PR TITLE
Serializing Grid and more robust grid comparisons

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -29,7 +29,7 @@ Grid attributes
     Grid.dy
     Grid.x0
     Grid.y0
-    Grid.order
+    Grid.origin
     Grid.pixel_ref
     Grid.x_coord
     Grid.y_coord
@@ -52,10 +52,11 @@ Grid methods
 
     Grid.extent_in_crs
     Grid.ij_to_crs
-    Grid.map_gridded_data
+    Grid.almost_equal
     Grid.region_of_interest
     Grid.regrid
     Grid.transform
+    Grid.map_gridded_data
     Grid.grid_lookup
     Grid.lookup_transform
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -59,6 +59,10 @@ Grid methods
     Grid.map_gridded_data
     Grid.grid_lookup
     Grid.lookup_transform
+    Grid.to_dict
+    Grid.from_dict
+    Grid.to_json
+    Grid.from_json
 
 
 Georeferencing utils

--- a/docs/gis.rst
+++ b/docs/gis.rst
@@ -53,7 +53,7 @@ this projection, a grid spacing and a number of grid points:
     import salem
     from salem import wgs84
 
-    grid = salem.Grid(nxny=(3, 2), dxdy=(1, 1), ll_corner=(0.5, 0.5), proj=wgs84)
+    grid = salem.Grid(nxny=(3, 2), dxdy=(1, 1), x0y0=(0.5, 0.5), proj=wgs84)
     x, y = grid.xy_coordinates
     x
     y
@@ -75,7 +75,7 @@ the two conventions are identical:
 
 .. ipython:: python
 
-    grid_c = salem.Grid(nxny=(3, 2), dxdy=(1, 1), ll_corner=(0, 0),
+    grid_c = salem.Grid(nxny=(3, 2), dxdy=(1, 1), x0y0=(0, 0),
                         proj=wgs84, pixel_ref='corner')
     assert grid_c == grid
 

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -28,6 +28,8 @@ Enhancements
   By `Daniel Rothenberg <https://github.com/darothen>`_
 - new :py:func:`~DataArrayAccessor.lookup_transform` projection transform
 - ``Grid`` objects now have a decent ``__repr__``
+- new serialization methods for grid: ``to_dict``, ``from_dict``, ``to_json``,
+  ``from_json``.
 
 
 Bug fixes

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -35,9 +35,14 @@ Enhancements
 Bug fixes
 ~~~~~~~~~
 
-- ``grid.transform()`` now works with non numpy array type
+- ``grid.transform()`` now works with non-numpy array type
 - ``transform_geopandas()`` won't do inplace operation per default anymore
 - fixed bugs to prepare for upcoming xarray v0.9.0
+- ``setup.py`` makes cleaner version strings for development versions (like
+  xarray's)
+- joblib's caching directory is now "environment dependant" in order  to avoid
+  conda/not conda mismatches, and avoid other black-magic curses related to
+  caching.
 
 
 v0.2.0 (08 November 2016)

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -7,19 +7,35 @@ What's New
 v0.2.X (Unreleased)
 -------------------
 
+Deprecations
+~~~~~~~~~~~~
+
+- the ``corner``, ``ul_corner``, and ``ll_corner`` kwargs to grid
+  initialisation have been deprecated in favor of the more explicit ``x0y0``.
+- the Grid attribue ``order`` is now called ``origin``, and can have the values
+  ``"lower-left"`` or ``"upper-left"``
+
 Enhancements
 ~~~~~~~~~~~~
 
-- new ``open_mf_wrf_dataset`` function
+- new :py:func:`~open_mf_wrf_dataset` function
 - new ``deacc`` method added to DataArrayAccessors
+  By `SiMaria <https://github.com/SiMaria>`
 - new ``Map.transform()`` method to make over-plotting easier (experimental)
-- new **all_touched** argument added to ``Grid.region_of_interest()`` to pass through to  ``rasterio.features.rasterize``, tweaking how grid cells are included in the region of interest
+- new **all_touched** argument added to ``Grid.region_of_interest()`` to pass
+  through to  ``rasterio.features.rasterize``, tweaking how grid cells are
+  included in the region of interest.
+  By `Daniel Rothenberg <https://github.com/darothen>`_
+- new :py:func:`~DataArrayAccessor.lookup_transform` projection transform
+- ``Grid`` objects now have a decent ``__repr__``
+
 
 Bug fixes
 ~~~~~~~~~
 
 - ``grid.transform()`` now works with non numpy array type
 - ``transform_geopandas()`` won't do inplace operation per default anymore
+- fixed bugs to prepare for upcoming xarray v0.9.0
 
 
 v0.2.0 (08 November 2016)

--- a/salem/datasets.py
+++ b/salem/datasets.py
@@ -184,8 +184,7 @@ class GeoDataset(object):
         dxdy = (self._ogrid.dx, self._ogrid.dy)
         xy0 = (self._ogrid.x0 + sub_x[0] * self._ogrid.dx,
                self._ogrid.y0 + sub_y[0] * self._ogrid.dy)
-        self.grid = Grid(proj=self._ogrid.proj, nxny=nxny, dxdy=dxdy,
-                         corner=xy0)
+        self.grid = Grid(proj=self._ogrid.proj, nxny=nxny, dxdy=dxdy, x0y0=xy0)
         # If we arrived here, we can safely set the subset
         self.sub_x = sub_x
         self.sub_y = sub_y
@@ -206,7 +205,7 @@ class GeoDataset(object):
         corners: a ((x0, y0), (x1, y1)) tuple of the corners of the square
         to subset the dataset to. The coordinates are not expressed in
         wgs84, set the crs keyword
-        noerase: set to true in order to add the new ROI to the previous one
+        noerase: set to true in origin to add the new ROI to the previous one
         """
 
         # The rois are always defined on the original grids, but of course
@@ -280,7 +279,7 @@ class GeoTiff(GeoDataset):
                 ul_corner = (src.bounds.left, src.bounds.top)
                 proj = pyproj.Proj(src.crs)
                 dxdy = (src.res[0], -src.res[1])
-                grid = Grid(ul_corner=ul_corner, nxny=nxny, dxdy=dxdy,
+                grid = Grid(x0y0=ul_corner, nxny=nxny, dxdy=dxdy,
                             pixel_ref='corner', proj=proj)
         # done
         self.file = file
@@ -330,7 +329,7 @@ class EsriITMIX(GeoDataset):
                 nxny = (src.width, src.height)
                 ul_corner = (src.bounds.left, src.bounds.top)
                 dxdy = (src.res[0], -src.res[1])
-                grid = Grid(ul_corner=ul_corner, nxny=nxny, dxdy=dxdy,
+                grid = Grid(x0y0=ul_corner, nxny=nxny, dxdy=dxdy,
                             pixel_ref='corner', proj=proj)
         # done
         self.file = file

--- a/salem/datasets.py
+++ b/salem/datasets.py
@@ -205,7 +205,7 @@ class GeoDataset(object):
         corners: a ((x0, y0), (x1, y1)) tuple of the corners of the square
         to subset the dataset to. The coordinates are not expressed in
         wgs84, set the crs keyword
-        noerase: set to true in origin to add the new ROI to the previous one
+        noerase: set to true in order to add the new ROI to the previous one
         """
 
         # The rois are always defined on the original grids, but of course

--- a/salem/gis.py
+++ b/salem/gis.py
@@ -55,6 +55,10 @@ def check_crs(crs):
     except:
         pass
 
+    if isinstance(crs, string_types):
+        # necessary for python 2
+        crs = str(crs)
+
     if isinstance(crs, pyproj.Proj) or isinstance(crs, Grid):
         out = crs
     elif isinstance(crs, dict) or isinstance(crs, string_types):

--- a/salem/gis.py
+++ b/salem/gis.py
@@ -1027,6 +1027,71 @@ class Grid(object):
 
         return mask
 
+    def to_dict(self):
+        """Serialize this grid to a dictionary.
+
+        Returns
+        -------
+        a grid dictionary
+
+        See Also
+        --------
+        ``Grid.from_dict``
+        """
+        return dict(proj=self.proj.srs, x0y0=(self.x0, self.y0),
+                    nxny=(self.nx, self.ny), dxdy=(self.dx, self.dy),
+                    pixel_ref=self.pixel_ref)
+
+    @classmethod
+    def from_dict(self, d):
+        """Create a Grid from a dictionary
+
+        Parameters
+        ----------
+        d : dict, required
+            the dict
+
+        Returns
+        -------
+        a salem.Grid instance
+        """
+        return Grid(**d)
+
+    def to_json(self, fpath):
+        """Serialize this grid to a json file.
+
+        Parameters
+        ----------
+        fpath : str, required
+            the path to the file to create
+
+        See Also
+        --------
+        ``Grid.from_json``
+        """
+        import json
+        with open(fpath, 'w') as fp:
+            json.dump(self.to_dict(), fp)
+
+    @classmethod
+    def from_json(self, fpath):
+        """Create a Grid from a json file
+
+        Parameters
+        ----------
+        fpath : str, required
+            the path to the file to open
+
+        Returns
+        -------
+        a salem.Grid instance
+        """
+        import json
+        with open(fpath, 'r') as fp:
+            d = json.load(fp)
+        return Grid.from_dict(d)
+
+
 
 def proj_is_same(p1, p2):
     """Checks is two pyproj projections are equal.

--- a/salem/gis.py
+++ b/salem/gis.py
@@ -141,13 +141,19 @@ class Grid(object):
         nxny : (int, int)
             (nx, ny) number of grid points
         dxdy : (float, float)
-            (dx, dy) grid spacing in proj coordinates
+            (dx, dy) grid spacing in proj coordinates. dx must be positive,
+            while dy can be positive or negative depending on the origin
+            grid point's lecation (upper-left or lower-left)
         x0y0 : (float, float)
             (x0, y0) cartesian coordinates (in proj) of the upper left
             or lower left corner, depending on the sign of dy
         pixel_ref : str
             either 'center' or 'corner' (default: 'center'). Tells
-            the Grid object where the (x0, y0) is located in the grid point
+            the Grid object where the (x0, y0) is located in the grid point.
+            If ``pixel_ref`` is set to 'corner' and dy < 0, the ``x0y0``
+            kwarg specifies the **grid point's upper left** corner
+            coordinates.  Equivalently, if dy > 0, x0y0 specifies the
+            **grid point's lower left** coordinate.
         corner : (float, float)
             DEPRECATED in favor of ``x0y0``
             (x0, y0) cartesian coordinates (in proj) of the upper left
@@ -158,13 +164,6 @@ class Grid(object):
         ll_corner : (float, float)
             DEPRECATED in favor of ``x0y0``
             (x0, y0) cartesian coordinates (in proj) of the lower left corner
-
-        Notes
-        -----
-        If pixel_ref is set to 'corner' and dy < 0, the x0y0
-        parameter specifies the **grid point's upper left** corner
-        coordinates.  Equivalently, if dy > 0 parameter x0y0 then specifies the
-        **grid point's lower left** coordinate.
 
         Examples
         --------

--- a/salem/graphics.py
+++ b/salem/graphics.py
@@ -413,7 +413,7 @@ class Map(DataLevels):
             ny = None
 
         self.grid = grid.center_grid.regrid(nx=nx, ny=ny, factor=factor)
-        self.origin = 'lower' if self.grid.order == 'll' else 'upper'
+        self.origin = 'lower' if self.grid.origin == 'lower-left' else 'upper'
 
         DataLevels.__init__(self, **kwargs)
 
@@ -887,7 +887,7 @@ class Map(DataLevels):
                 img = imread(utils.get_natural_earth_file(natural_earth))
             ny, nx = img.shape[0], img.shape[1]
             dx, dy = 360. / nx, 180. / ny
-            grid = Grid(nxny=(nx, ny), dxdy=(dx, -dy), ul_corner=(-180., 90.),
+            grid = Grid(nxny=(nx, ny), dxdy=(dx, -dy), x0y0=(-180., 90.),
                         pixel_ref='corner').center_grid
             return self.set_rgb(img, grid, interp='linear')
 

--- a/salem/sio.py
+++ b/salem/sio.py
@@ -81,13 +81,15 @@ def read_shapefile(fpath, cached=False):
 
 
 @memory.cache(ignore=['grid'])
-def _memory_transform(shape_cpath, grid=None, grid_str=None):
+def _memory_shapefile_to_grid(shape_cpath, grid=None,
+                              nxny=None, pixel_ref=None, x0y0=None, dxdy=None,
+                              proj=None):
     """Quick solution using joblib in order to not transform many times the
     same shape (useful for maps).
 
-    Since grid is a complex object joblib seemed to have trouble with it,
-    so joblib is checking its cache according to grid_str while the job is
-    done with grid.
+    Since grid is a complex object, joblib seems to have trouble with it.
+    So joblib is checking its cache according to the grid params while the job
+    is done with grid.
     """
 
     shape = read_shapefile(shape_cpath, cached=True)
@@ -101,7 +103,7 @@ def _memory_transform(shape_cpath, grid=None, grid_str=None):
     return shape
 
 
-def read_shapefile_to_grid(fpath, grid, use_cache=True):
+def read_shapefile_to_grid(fpath, grid):
     """Same as read_shapefile but directly transformed to a grid.
 
     The whole thing is cached so that the second call will
@@ -111,17 +113,17 @@ def read_shapefile_to_grid(fpath, grid, use_cache=True):
     ----------
     fpath: path to the file
     grid: the arrival grid
-    use_cache: use the cache or not
     """
 
     # ensure it is a cached pickle (copy code smell)
     shape_cpath = cached_shapefile_path(fpath)
-    if not os.path.exists(shape_cpath) or not use_cache:
+    if not os.path.exists(shape_cpath):
         out = read_shapefile(fpath, cached=False)
         with open(shape_cpath, 'wb') as f:
             pickle.dump(out, f)
 
-    return _memory_transform(shape_cpath, grid=grid, grid_str=str(grid))
+    return _memory_shapefile_to_grid(shape_cpath, grid=grid,
+                                     **grid.to_dict())
 
 
 # TODO: remove this once we sure that we have all WRF files right

--- a/salem/sio.py
+++ b/salem/sio.py
@@ -82,7 +82,7 @@ def read_shapefile(fpath, cached=False):
 
 @memory.cache(ignore=['grid'])
 def _memory_transform(shape_cpath, grid=None, grid_str=None):
-    """Quick solution using joblib in order to not transform many times the
+    """Quick solution using joblib in origin to not transform many times the
     same shape (useful for maps).
 
     Since grid is a complex object joblib seemed to have trouble with it,
@@ -195,8 +195,7 @@ def _wrf_grid_from_dataset(ds):
         e, n = gis.transform_proj(wgs84, proj, cen_lon, cen_lat)
         x0 = -(nx-1) / 2. * dx + e  # DL corner
         y0 = -(ny-1) / 2. * dy + n  # DL corner
-    grid = gis.Grid(nxny=(nx, ny), ll_corner=(x0, y0), dxdy=(dx, dy),
-                    proj=proj)
+    grid = gis.Grid(nxny=(nx, ny), x0y0=(x0, y0), dxdy=(dx, dy), proj=proj)
 
     if tmp_check_wrf:
         #  Temporary asserts
@@ -261,8 +260,8 @@ def _lonlat_grid_from_dataset(ds):
     # Make the grid
     dx = lon[1]-lon[0]
     dy = lat[1]-lat[0]
-    args = dict(nxny=(lon.shape[0], lat.shape[0]), proj=wgs84, dxdy=(dx, dy))
-    args['corner'] = (lon[0], lat[0])
+    args = dict(nxny=(lon.shape[0], lat.shape[0]), proj=wgs84, dxdy=(dx, dy),
+                x0y0=(lon[0], lat[0]))
     return gis.Grid(**args)
 
 
@@ -307,8 +306,8 @@ def _salem_grid_from_dataset(ds):
     # Make the grid
     dx = x[1]-x[0]
     dy = y[1]-y[0]
-    args = dict(nxny=(x.shape[0], y.shape[0]), proj=proj, dxdy=(dx, dy))
-    args['corner'] = (x[0], y[0])
+    args = dict(nxny=(x.shape[0], y.shape[0]), proj=proj, dxdy=(dx, dy),
+                x0y0=(x[0], y[0]))
     return gis.Grid(**args)
 
 

--- a/salem/sio.py
+++ b/salem/sio.py
@@ -82,7 +82,7 @@ def read_shapefile(fpath, cached=False):
 
 @memory.cache(ignore=['grid'])
 def _memory_transform(shape_cpath, grid=None, grid_str=None):
-    """Quick solution using joblib in origin to not transform many times the
+    """Quick solution using joblib in order to not transform many times the
     same shape (useful for maps).
 
     Since grid is a complex object joblib seemed to have trouble with it,

--- a/salem/tests/test_datasets.py
+++ b/salem/tests/test_datasets.py
@@ -2,7 +2,6 @@ from __future__ import division
 
 import unittest
 import warnings
-import os
 from datetime import datetime
 
 
@@ -44,7 +43,7 @@ class TestDataset(unittest.TestCase):
     def test_period(self):
         """See if simple operations work well"""
 
-        g = Grid(nxny=(3, 3), dxdy=(1, 1), ll_corner=(0, 0), proj=wgs84)
+        g = Grid(nxny=(3, 3), dxdy=(1, 1), x0y0=(0, 0), proj=wgs84)
         d = GeoDataset(g)
         self.assertTrue(d.time is None)
         self.assertTrue(d.sub_t is None)
@@ -87,7 +86,7 @@ class TestDataset(unittest.TestCase):
     def test_subset(self):
         """See if simple operations work well"""
 
-        g = Grid(nxny=(3, 3), dxdy=(1, 1), ll_corner=(0, 0), proj=wgs84)
+        g = Grid(nxny=(3, 3), dxdy=(1, 1), x0y0=(0, 0), proj=wgs84)
         d = GeoDataset(g)
         self.assertTrue(isinstance(d, GeoDataset))
         self.assertEqual(g, d.grid)
@@ -109,7 +108,7 @@ class TestDataset(unittest.TestCase):
         d.set_subset(corners=([0.51, 0.51], [1.9, 1.9]), crs=wgs84)
         self.assertNotEqual(g, d.grid)
 
-        gm = Grid(nxny=(1, 1), dxdy=(1, 1), ll_corner=(1, 1), proj=wgs84)
+        gm = Grid(nxny=(1, 1), dxdy=(1, 1), x0y0=(1, 1), proj=wgs84)
         d.set_subset(corners=([1, 1], [1, 1]), crs=wgs84)
         self.assertEqual(gm, d.grid)
 
@@ -119,7 +118,7 @@ class TestDataset(unittest.TestCase):
         d.set_subset(toroi=True)
         self.assertEqual(gm, d.grid)
 
-        gm = Grid(nxny=(1, 1), dxdy=(1, 1), ll_corner=(2, 2), proj=wgs84)
+        gm = Grid(nxny=(1, 1), dxdy=(1, 1), x0y0=(2, 2), proj=wgs84)
         d.set_subset(corners=([2, 2], [2, 2]), crs=wgs84)
         self.assertEqual(gm, d.grid)
 
@@ -149,7 +148,7 @@ class TestDataset(unittest.TestCase):
         # same errors as IDL: ENVI is just wrong
         self.assertTrue(np.sum(ref != d.roi) < 9)
 
-        g = Grid(nxny=(3, 3), dxdy=(1, 1), ll_corner=(0, 0), proj=wgs84,
+        g = Grid(nxny=(3, 3), dxdy=(1, 1), x0y0=(0, 0), proj=wgs84,
                  pixel_ref='corner')
         p = shpg.Polygon([(1.5, 1.), (2., 1.5), (1.5, 2.), (1., 1.5)])
         roi = g.region_of_interest(geometry=p)
@@ -241,7 +240,7 @@ class TestGeoNetcdf(unittest.TestCase):
 
         f = get_demo_file('era_interim_tibet.nc')
         d = GeoNetcdf(f)
-        assert d.grid.order == 'ul'
+        assert d.grid.origin == 'upper-left'
 
         stat_lon = 91.1
         stat_lat = 31.1

--- a/salem/tests/test_gis.py
+++ b/salem/tests/test_gis.py
@@ -14,7 +14,7 @@ from salem import wgs84
 import salem.gis as gis
 from salem.utils import get_demo_file
 from salem.tests import requires_xarray, requires_shapely, requires_geopandas, \
-    requires_cartopy, requires_rasterio
+    requires_cartopy, requires_rasterio, python_version
 
 
 
@@ -86,13 +86,14 @@ class TestGrid(unittest.TestCase):
             args['nxny'] = (3, 3)
 
             args['dxdy'] = (1, -1)
-            # args['ll_corner'] = args['x0y0']
-            # del args['x0y0']
-            # with warnings.catch_warnings(record=True) as w:
-            #     self.assertRaises(ValueError, Grid, **args)
-            #     self.assertEqual(len(w), 1)
-            # args['x0y0'] = args['ll_corner']
-            # del args['ll_corner']
+            args['ll_corner'] = args['x0y0']
+            del args['x0y0']
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter('always')
+                self.assertRaises(ValueError, Grid, **args)
+                self.assertEqual(len(w), 1)
+            args['x0y0'] = args['ll_corner']
+            del args['ll_corner']
 
             # Center VS corner - multiple times because it was a bug
             assert_allclose(g.center_grid.xy_coordinates,
@@ -504,6 +505,7 @@ class TestGrid(unittest.TestCase):
         odata = g2.lookup_transform(data4d, g)
         assert_allclose(odata, data4d[..., :-1, :-1])
 
+        f = self.assertRaisesRegex if python_version == 'py3' else self.assertRaisesRegexp
         with self.assertRaisesRegex(ValueError, 'dimension not compatible'):
             g.lookup_transform(data2d[:-1, :-1], g)
 

--- a/salem/tests/test_gis.py
+++ b/salem/tests/test_gis.py
@@ -506,7 +506,7 @@ class TestGrid(unittest.TestCase):
         assert_allclose(odata, data4d[..., :-1, :-1])
 
         f = self.assertRaisesRegex if python_version == 'py3' else self.assertRaisesRegexp
-        with self.assertRaisesRegex(ValueError, 'dimension not compatible'):
+        with f(ValueError, 'dimension not compatible'):
             g.lookup_transform(data2d[:-1, :-1], g)
 
         odata = g.lookup_transform(data2d[:-1, :-1], g2)

--- a/salem/tests/test_gis.py
+++ b/salem/tests/test_gis.py
@@ -297,7 +297,8 @@ class TestGrid(unittest.TestCase):
                 args = dict(nxny=(3, 3), dxdy=(1, 1), ll_corner=(0, 0),
                             proj=proj)
                 Grid(**args)
-                self.assertEqual(len(w), 3)
+                if python_version == 'py3':
+                    self.assertEqual(len(w), 3)
 
     def test_ij_to_crs(self):
         """Converting to projection"""

--- a/salem/tests/test_graphics.py
+++ b/salem/tests/test_graphics.py
@@ -178,12 +178,12 @@ def test_simple_map():
     fs = _create_dummy_shp('fs.shp')
 
     # UL Corner
-    g1 = Grid(nxny=(5, 4), dxdy=(1, -1), ul_corner=(-1, 3), proj=wgs84,
+    g1 = Grid(nxny=(5, 4), dxdy=(1, -1), x0y0=(-1, 3), proj=wgs84,
               pixel_ref='corner')
     c1 = Map(g1, ny=4, countries=False)
 
     # LL Corner
-    g2 = Grid(nxny=(5, 4), dxdy=(1, 1), ll_corner=(-1, -1), proj=wgs84,
+    g2 = Grid(nxny=(5, 4), dxdy=(1, 1), x0y0=(-1, -1), proj=wgs84,
               pixel_ref='corner')
     c2 = Map(g2, ny=4, countries=False)
 
@@ -243,7 +243,7 @@ def test_contourf():
     a[3, 3] = 9
 
     # UL Corner
-    g = Grid(nxny=(5, 4), dxdy=(1, -1), ul_corner=(-1, 3), proj=wgs84,
+    g = Grid(nxny=(5, 4), dxdy=(1, -1), x0y0=(-1, 3), proj=wgs84,
              pixel_ref='corner')
     c = Map(g, ny=400, countries=False)
 
@@ -284,7 +284,7 @@ def test_merca_map():
 
     grid = mercator_grid(center_ll=(11.38, 47.26),
                          extent=(2000000, 2000000),
-                         order='ul')
+                         origin='upper-left')
     m2 = Map(grid)
 
     fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(12, 6))
@@ -331,7 +331,7 @@ def test_oceans():
 @pytest.mark.mpl_image_compare(baseline_dir='baseline_images')
 def test_geometries():
     # UL Corner
-    g = Grid(nxny=(5, 4), dxdy=(10, 10), ll_corner=(-20, -15), proj=wgs84,
+    g = Grid(nxny=(5, 4), dxdy=(10, 10), x0y0=(-20, -15), proj=wgs84,
              pixel_ref='corner')
     c = Map(g, ny=4)
     c.set_lonlat_contours(interval=10., colors='crimson')
@@ -371,7 +371,7 @@ def test_geometries():
 @pytest.mark.mpl_image_compare(baseline_dir='baseline_images')
 def test_text():
     # UL Corner
-    g = Grid(nxny=(5, 4), dxdy=(10, 10), ll_corner=(-20, -15), proj=wgs84,
+    g = Grid(nxny=(5, 4), dxdy=(10, 10), x0y0=(-20, -15), proj=wgs84,
              pixel_ref='corner')
     c = Map(g, ny=4, countries=False)
     c.set_lonlat_contours(interval=5., colors='crimson')

--- a/salem/tests/test_misc.py
+++ b/salem/tests/test_misc.py
@@ -69,6 +69,11 @@ class TestUtils(unittest.TestCase):
     def test_empty_cache(self):
         utils.empty_cache()
 
+    def test_joblibcache(self):
+        h1 = utils._joblib_cache_dir()
+        h2 = utils._joblib_cache_dir()
+        self.assertEqual(h1, h2)
+
     def test_demofiles(self):
 
         self.assertTrue(os.path.exists(utils.get_demo_file('dem_wgs84.nc')))
@@ -132,11 +137,28 @@ class TestIO(unittest.TestCase):
         g = GeoTiff(utils.get_demo_file('hef_srtm.tif'))
         sf = utils.get_demo_file('Hintereisferner_UTM.shp')
 
-        df1 = read_shapefile_to_grid(sf, g.grid, use_cache=False)
+        df1 = read_shapefile_to_grid(sf, g.grid)
 
         df2 = transform_geopandas(read_shapefile(sf), to_crs=g.grid)
         assert_allclose(df1.geometry[0].exterior.coords,
                         df2.geometry[0].exterior.coords)
+
+        # test for caching
+        d = g.grid.to_dict()
+        # change key ordering by chance
+        d2 = dict((k, v) for k, v in d.items())
+
+        from salem.sio import _memory_shapefile_to_grid, cached_shapefile_path
+        shape_cpath = cached_shapefile_path(sf)
+        res = _memory_shapefile_to_grid.call_and_shelve(shape_cpath,
+                                                        grid=g.grid,
+                                                        **d)
+        h1 = res.argument_hash
+        res = _memory_shapefile_to_grid.call_and_shelve(shape_cpath,
+                                                        grid=g.grid,
+                                                        **d2)
+        h2 = res.argument_hash
+        self.assertEqual(h1, h2)
 
 
     @requires_xarray

--- a/salem/tests/test_misc.py
+++ b/salem/tests/test_misc.py
@@ -345,7 +345,7 @@ class TestGraphics(unittest.TestCase):
         cmap = copy.deepcopy(mpl.cm.get_cmap('jet'))
 
         # ll_corner (type geotiff)
-        g = Grid(nxny=(5, 4), dxdy=(1, 1), ll_corner=(0, 0), proj=wgs84,
+        g = Grid(nxny=(5, 4), dxdy=(1, 1), x0y0=(0, 0), proj=wgs84,
                  pixel_ref='corner')
         c = graphics.Map(g, ny=4, countries=False)
         c.set_cmap(cmap)
@@ -360,7 +360,7 @@ class TestGraphics(unittest.TestCase):
         assert_array_equal(rgb1, c.to_rgb())
 
         # centergrid (type WRF)
-        g = Grid(nxny=(5, 4), dxdy=(1, 1), ll_corner=(0.5, 0.5), proj=wgs84,
+        g = Grid(nxny=(5, 4), dxdy=(1, 1), x0y0=(0.5, 0.5), proj=wgs84,
                  pixel_ref='center')
         c = graphics.Map(g, ny=4, countries=False)
         c.set_cmap(cmap)

--- a/salem/utils.py
+++ b/salem/utils.py
@@ -26,8 +26,9 @@ def _joblib_cache_dir():
 
     We need to make sure that cached files correspond to the same
     environment. To this end we make a unique directory hash, depending on the
-    version and location of several packages we thought are important because
-    they change often.
+    version and location of several packages we thought are important
+    (because they change often, or because conda versions give different
+    results than pip versions).
 
     Returns
     -------
@@ -59,6 +60,12 @@ def _joblib_cache_dir():
         import osgeo
         out['osgeo_version'] = osgeo.__version__
         out['osgeo_file'] = osgeo.__file__
+    except ImportError:
+        pass
+    try:
+        import pyproj
+        out['pyproj_version'] = pyproj.__version__
+        out['pyproj_file'] = pyproj.__file__
     except ImportError:
         pass
     try:

--- a/salem/utils.py
+++ b/salem/utils.py
@@ -9,6 +9,7 @@ import os
 import shutil
 import time
 import zipfile
+from collections import OrderedDict
 
 import numpy as np
 from joblib import Memory
@@ -17,7 +18,67 @@ from six.moves.urllib.error import HTTPError, URLError
 from six.moves.urllib.request import urlretrieve, urlopen
 
 # Joblib
-memory = Memory(cachedir=cache_dir, verbose=0)
+
+
+
+def _joblib_cache_dir():
+    """Get the path to the right joblib directory.
+
+    We need to make sure that cached files correspond to the same
+    environment. To this end we make a unique directory hash, depending on the
+    version and location of several packages we thought are important because
+    they change often.
+
+    Returns
+    -------
+    path to the dir
+    """
+    import hashlib
+
+    out = OrderedDict(python_version=python_version)
+
+    try:
+        import shapely
+        out['shapely_version'] = shapely.__version__
+        out['shapely_file'] = shapely.__file__
+    except ImportError:
+        pass
+    try:
+        import fiona
+        out['fiona_version'] = fiona.__version__
+        out['fiona_file'] = fiona.__file__
+    except ImportError:
+        pass
+    try:
+        import geopandas
+        out['geopandas_version'] = geopandas.__version__
+        out['geopandas_file'] = geopandas.__file__
+    except ImportError:
+        pass
+    try:
+        import osgeo
+        out['osgeo_version'] = osgeo.__version__
+        out['osgeo_file'] = osgeo.__file__
+    except ImportError:
+        pass
+    try:
+        import salem
+        out['salem_version'] = salem.__version__
+        out['salem_file'] = salem.__file__
+    except ImportError:
+        pass
+
+    # ok, now make a dummy str that we will hash
+    strout = ''
+    for k, v in out.items():
+        strout += k + v
+    strout = 'salem_hash_' + hashlib.md5(strout.encode()).hexdigest()
+    dirout = os.path.join(cache_dir, 'joblib', strout)
+    if not os.path.exists(dirout):
+        os.makedirs(dirout)
+    return dirout
+
+memory = Memory(cachedir=_joblib_cache_dir(), verbose=0)
 
 # A series of variables and dimension names that Salem will understand
 valid_names = dict()
@@ -79,7 +140,8 @@ def cached_shapefile_path(fpath):
 
     # Cached directory and file
     cp = os.path.commonprefix([cache_dir, p])
-    cp = os.path.join(cache_dir, python_version, os.path.relpath(p, cp))
+    cp = os.path.join(cache_dir, python_version + '_cache',
+                      os.path.relpath(p, cp))
     ct = '{:d}'.format(int(round(os.path.getmtime(fpath)*1000.)))
     of = os.path.join(cp, ct + '.p')
     if os.path.exists(cp):

--- a/salem/wrftools.py
+++ b/salem/wrftools.py
@@ -661,8 +661,7 @@ def geogrid_simulator(fpath, do_maps=True):
     y0 = -(ny-1) / 2. * dy + n
 
     # parent grid
-    grid = gis.Grid(nxny=(nx, ny), ll_corner=(x0, y0), dxdy=(dx, dy),
-                    proj=pwrf)
+    grid = gis.Grid(nxny=(nx, ny), x0y0=(x0, y0), dxdy=(dx, dy), proj=pwrf)
 
     # child grids
     out = [grid]
@@ -689,7 +688,7 @@ def geogrid_simulator(fpath, do_maps=True):
         dx = prevgrid.dx / ratio
         dy = prevgrid.dy / ratio
         grid = gis.Grid(nxny=(we, sn),
-                        ll_corner=(xx[ips], yy[jps]),
+                        x0y0=(xx[ips], yy[jps]),
                         dxdy=(dx, dy),
                         pixel_ref='corner',
                         proj=pwrf)

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,9 @@
 from setuptools import setup, find_packages  # Always prefer setuptools
 from codecs import open  # To use a consistent encoding
 from os import path, walk
+import re
+import sys
+import warnings
 import importlib
 
 MAJOR = 0
@@ -45,7 +48,45 @@ FULLVERSION = VERSION
 write_version = True
 
 if not ISRELEASED:
-    FULLVERSION += '.dev0'
+    import subprocess
+    FULLVERSION += '.dev'
+
+    pipe = None
+    for cmd in ['git', 'git.cmd']:
+        try:
+            pipe = subprocess.Popen(
+                [cmd, "describe", "--always", "--match", "v[0-9]*"],
+                stdout=subprocess.PIPE)
+            (so, serr) = pipe.communicate()
+            if pipe.returncode == 0:
+                break
+        except:
+            pass
+
+    if pipe is None or pipe.returncode != 0:
+        # no git, or not in git dir
+        if path.exists('salem/version.py'):
+            warnings.warn("WARNING: Couldn't get git revision, using existing "
+                          "salem/version.py")
+            write_version = False
+        else:
+            warnings.warn("WARNING: Couldn't get git revision, using generic "
+                          "version string")
+    else:
+        # have git, in git dir, but may have used a shallow clone (travis)
+        rev = so.strip()
+        # makes distutils blow up on Python 2.7
+        if sys.version_info[0] >= 3:
+            rev = rev.decode('ascii')
+
+        if not rev.startswith('v') and re.match("[a-zA-Z0-9]{7,9}", rev):
+            # partial clone, manually construct version string
+            # this is the format before we started using git-describe
+            # to get an ordering on dev version strings.
+            rev = "v%s.dev-%s" % (VERSION, rev)
+
+        # Strip leading v from tags format "vx.y.z" to get th version string
+        FULLVERSION = rev.lstrip('v')
 else:
     FULLVERSION += QUALIFIER
 


### PR DESCRIPTION
Todos:
- [x] deprecate some unpythonic grid attributes and kwargs
- [x] new grid __repr__
- [x] more robust grid comparisons
- [x] seriazlization to dict and json (https://github.com/fmaussion/salem/issues/53)
- [x] caching: make a specific cache for package versions: unfortunately this is necessary (pyproj, gdal, etc.)
- [x] caching: read_shapefile_on grid whould become more robust too