### PR TITLE
GoogleMap scale factor

### DIFF
--- a/salem/datasets.py
+++ b/salem/datasets.py
@@ -475,7 +475,8 @@ class GoogleCenterMap(GeoDataset):
     """
 
     def __init__(self, center_ll=(11.38, 47.26), size_x=640, size_y=640,
-                 zoom=12, maptype='satellite', use_cache=True, **kwargs):
+                 scale=1, zoom=12, maptype='satellite', use_cache=True, 
+                 **kwargs):
         """Initialize
 
         Parameters
@@ -486,6 +487,8 @@ class GoogleCenterMap(GeoDataset):
           image size
         size_y : int
           image size
+        scale : int
+          image scaling factor
         zoom int
           google zoom level (https://developers.google.com/maps/documentation/
           static-maps/intro#Zoomlevels)
@@ -497,18 +500,19 @@ class GoogleCenterMap(GeoDataset):
           any keyword accepted by motionless.CenterMap (e.g. `key` for the API)
         """
 
-        if 'scale' in kwargs:
-            raise NotImplementedError('scale not supported')
+        if scale < 0 or scale > 2 or type(scale) is not int:
+            raise ValueError('incompatible value of scale')
 
         # Google grid
         grid = gis.googlestatic_mercator_grid(center_ll=center_ll,
                                                 nx=size_x, ny=size_y,
-                                                zoom=zoom)
+                                                zoom=zoom, scale=scale)
 
         # Motionless
         googleurl = motionless.CenterMap(lon=center_ll[0], lat=center_ll[1],
                                          size_x=size_x, size_y=size_y,
-                                         maptype=maptype, zoom=zoom, **kwargs)
+                                         maptype=maptype, zoom=zoom, scale=scale, 
+                                         **kwargs)
 
         # done
         self.googleurl = googleurl
@@ -536,7 +540,7 @@ class GoogleVisibleMap(GoogleCenterMap):
     It's usually more practical to use than GoogleCenterMap.
     """
 
-    def __init__(self, x, y, crs=wgs84, size_x=640, size_y=640,
+    def __init__(self, x, y, crs=wgs84, size_x=640, size_y=640, scale=1,
                  maptype='satellite', use_cache=True, **kwargs):
         """Initialize
 
@@ -552,6 +556,8 @@ class GoogleVisibleMap(GoogleCenterMap):
           image size
         size_y : int
           image size
+        scale : int
+          image scaling factor
         maptype : str, default: 'satellite'
           'roadmap', 'satellite', 'hybrid', 'terrain'
         use_cache : bool, default: True
@@ -562,6 +568,9 @@ class GoogleVisibleMap(GoogleCenterMap):
 
         if 'zoom' in kwargs or 'center_ll' in kwargs:
             raise ValueError('incompatible kwargs.')
+
+        if scale < 0 or scale > 2 or type(scale) is not int:
+            raise ValueError('incompatible value of scale')
 
         # Transform to lonlat
         crs = gis.check_crs(crs)
@@ -576,8 +585,10 @@ class GoogleVisibleMap(GoogleCenterMap):
         mc = (np.mean(lon), np.mean(lat))
         zoom = 20
         while zoom >= 0:
+            print zoom
             grid = gis.googlestatic_mercator_grid(center_ll=mc, nx=size_x,
-                                                  ny=size_y, zoom=zoom)
+                                                  ny=size_y, zoom=zoom,
+                                                  scale=scale)
             dx, dy = grid.transform(lon, lat, maskout=True)
             if np.any(dx.mask):
                 zoom -= 1
@@ -585,5 +596,5 @@ class GoogleVisibleMap(GoogleCenterMap):
                 break
 
         GoogleCenterMap.__init__(self, center_ll=mc, size_x=size_x,
-                                 size_y=size_y, zoom=zoom, maptype=maptype,
-                                 use_cache=use_cache, **kwargs)
+                                 size_y=size_y, zoom=zoom, scale=scale,
+                                 maptype=maptype, use_cache=use_cache, **kwargs)

--- a/salem/gis.py
+++ b/salem/gis.py
@@ -1437,14 +1437,14 @@ def mercator_grid(center_ll=None, extent=None, ny=600, nx=None,
                 pixel_ref='corner')
 
 
-def googlestatic_mercator_grid(center_ll=None, nx=640, ny=640, zoom=12):
+def googlestatic_mercator_grid(center_ll=None, nx=640, ny=640, zoom=12, scale=1):
     """Mercator map centered on a specified point (google API conventions).
 
     Mostly useful for google maps.
     """
 
     # Number of pixels in an image with a zoom level of 0.
-    google_pix = 256
+    google_pix = 256 * scale
     # The equitorial radius of the Earth assuming WGS-84 ellipsoid.
     google_earth_radius = 6378137.0
 
@@ -1455,12 +1455,13 @@ def googlestatic_mercator_grid(center_ll=None, nx=640, ny=640, zoom=12):
 
     # Meter per pixel
     mpix = (2 * np.pi * google_earth_radius) / google_pix / (2**zoom)
-    xx = nx * mpix
-    yy = ny * mpix
+    xx = nx * scale * mpix
+    yy = ny * scale * mpix
 
     e, n = pyproj.transform(wgs84, projloc, lon, lat)
     corner = (-xx / 2. + e, yy / 2. + n)
-    dxdy = (xx / nx, - yy / ny)
+    dxdy = (xx / nx / scale, - yy / ny / scale)
 
-    return Grid(proj=projloc, x0y0=corner, nxny=(nx, ny), dxdy=dxdy,
+    return Grid(proj=projloc, x0y0=corner, 
+                nxny=(nx * scale, ny * scale), dxdy=dxdy,
                 pixel_ref='corner')


### PR DESCRIPTION
To allow for Google static maps with a better resolution, the "scale" argument already present in motionless is now available from the GoogleMapCenter & GoogleMapVisible classes.
Safety has been added to limit user to "scale=1" or "scale=2".
