### PR TITLE
Remove compat code for old dask versions

### DIFF
--- a/salem/sio.py
+++ b/salem/sio.py
@@ -1127,12 +1127,7 @@ def open_mf_wrf_dataset(paths, chunks=None,  compat='no_conflicts', lock=None,
         raise IOError('no files to open')
 
     # TODO: current workaround to dask thread problems
-    try:
-        # dask < 0.16
-        get = dask.async.get_sync
-    except AttributeError:
-        get = dask.get
-    dask.set_options(get=get)
+    dask.set_options(get=dask.get)
 
     if lock is None:
         lock = _default_lock(paths[0], 'netcdf4')


### PR DESCRIPTION
async is a keyword now in python 3.7. So just having that line there causes a SyntaxError that cannot be caught.