### PR TITLE
Fix issues with pandas not understanding netCDFs datetime object

### DIFF
--- a/salem/sio.py
+++ b/salem/sio.py
@@ -1134,7 +1134,7 @@ def open_mf_wrf_dataset(paths, chunks=None,  compat='no_conflicts', lock=None,
         raise IOError('no files to open')
 
     # TODO: current workaround to dask thread problems
-    dask.set_options(get=dask.get)
+    dask.config.set(get=dask.get)
 
     if lock is None:
         lock = _default_lock(paths[0], 'netcdf4')

--- a/salem/sio.py
+++ b/salem/sio.py
@@ -378,6 +378,10 @@ def netcdf_time(ncobj, monthbegin=False):
         if monthbegin:
             # sometimes monthly data is centered in the month (stupid)
             time = [datetime(t.year, t.month, 1) for t in time]
+        else:
+            for t in time:
+                if not hasattr(t, 'nanosecond'):
+                    t.nanosecond = 0
 
     return time
 


### PR DESCRIPTION
Pandas seems to understand the objects returned like that just fine, so it seems like a valid workaround to me.