### PR TITLE
Fix some deprecation warnings

### DIFF
--- a/salem/gis.py
+++ b/salem/gis.py
@@ -1272,6 +1272,14 @@ def proj_is_same(p1, p2):
         return p1 == p2
 
 
+def _transform_internal(p1, p2, x, y, **kwargs):
+    if hasattr(pyproj, 'Transformer'):
+        trf = pyproj.Transformer.from_proj(p1, p2, **kwargs)
+        return trf.transform(x, y)
+    else:
+        return pyproj.transform(p1, p2, x, y, **kwargs)
+
+
 def transform_proj(p1, p2, x, y, nocopy=False):
     """Wrapper around the pyproj.transform function.
 
@@ -1297,8 +1305,8 @@ def transform_proj(p1, p2, x, y, nocopy=False):
 
     try:
         # This always makes a copy, even if projections are equivalent
-        return pyproj.transform(p1, p2, x, y,
-                                skip_equivalent=True, always_xy=True)
+        return _transform_internal(p1, p2, x, y,
+                                   skip_equivalent=True, always_xy=True)
     except TypeError:
         if proj_is_same(p1, p2):
             if nocopy:
@@ -1306,7 +1314,7 @@ def transform_proj(p1, p2, x, y, nocopy=False):
             else:
                 return copy.deepcopy(x), copy.deepcopy(y)
 
-        return pyproj.transform(p1, p2, x, y)
+        return _transform_internal(p1, p2, x, y)
 
 
 def transform_geometry(geom, crs=wgs84, to_crs=wgs84):

--- a/salem/gis.py
+++ b/salem/gis.py
@@ -1480,6 +1480,7 @@ def proj_to_cartopy(proj):
         if k == 'proj':
             if v == 'tmerc':
                 cl = ccrs.TransverseMercator
+                kw_proj['approx'] = True
             if v == 'lcc':
                 cl = ccrs.LambertConformal
             if v == 'merc':
@@ -1520,6 +1521,11 @@ def proj_to_cartopy(proj):
             kw_proj.pop('central_longitude', None)
     else:
         kw_proj.pop('latitude_true_scale', None)
+
+    try:
+        return cl(globe=globe, **kw_proj)
+    except TypeError:
+        del kw_proj['approx']
 
     return cl(globe=globe, **kw_proj)
 

--- a/salem/sio.py
+++ b/salem/sio.py
@@ -33,6 +33,9 @@ except ImportError:
     # latest xarray dropped python2 support, so we can safely assume py3 here
     basestring = str
 
+# Locals
+from salem import transform_proj
+
 
 def read_shapefile(fpath, cached=False):
     """Reads a shapefile using geopandas.
@@ -1029,7 +1032,7 @@ def is_rotated_proj_working():
     p1 = pyproj.Proj(srs)
     p2 = wgs84
 
-    return np.isclose(pyproj.transform(p1, p2, -20, -9),
+    return np.isclose(transform_proj(p1, p2, -20, -9),
                       [-22.243473889042903, -0.06328365194179102],
                       atol=1e-5).all()
 

--- a/salem/sio.py
+++ b/salem/sio.py
@@ -372,7 +372,7 @@ def netcdf_time(ncobj, monthbegin=False):
         except AttributeError:
             stimes = ncobj.variables['Times'][:]
         for t in stimes:
-            time.append(pd.to_datetime(t.tostring().decode(),
+            time.append(pd.to_datetime(t.tobytes().decode(),
                                        errors='raise',
                                        format='%Y-%m-%d_%H:%M:%S'))
     elif vt is not None:

--- a/salem/tests/test_gis.py
+++ b/salem/tests/test_gis.py
@@ -1021,11 +1021,6 @@ class TestTransform(unittest.TestCase):
         y = np.random.randn(int(1e6)) * 60
 
         for i in np.arange(3):
-            xx, yy = pyproj.transform(wgs84, wgs84, x, y)
-        assert_allclose(xx, x)
-        assert_allclose(yy, y)
-
-        for i in np.arange(3):
             xx, yy = gis.transform_proj(wgs84, wgs84, x, y)
         assert_allclose(xx, x)
         assert_allclose(yy, y)
@@ -1034,11 +1029,6 @@ class TestTransform(unittest.TestCase):
             xx, yy = gis.transform_proj(wgs84, wgs84, x, y, nocopy=True)
         assert_allclose(xx, x)
         assert_allclose(yy, y)
-
-        xx, yy = pyproj.transform(gis.check_crs('epsg:26915'),
-                                  gis.check_crs('epsg:26915'), x, y)
-        assert_allclose(xx, x, atol=1e-3)
-        assert_allclose(yy, y, atol=1e-3)
 
         xx, yy = gis.transform_proj(gis.check_crs('epsg:26915'),
                                     gis.check_crs('epsg:26915'), x, y)

--- a/salem/wrftools.py
+++ b/salem/wrftools.py
@@ -221,7 +221,7 @@ class AccumulatedVariable(FakeVariable):
             time = []
             stimes = vars['Times'][0:2]
             for t in stimes:
-                time.append(to_datetime(t.tostring().decode(),
+                time.append(to_datetime(t.tobytes().decode(),
                                         errors='raise',
                                         format='%Y-%m-%d_%H:%M:%S'))
             dt_minutes = time[1] - time[0]


### PR DESCRIPTION
tostring() has been replaced with the much more sensible name of tobytes(), given that it returns bytes and not a string, since Python 3.2.
It throws a ton of deprecation warnings since some update to Python 3.7, so lets fix it and silence those.