### PR TITLE
DOC: add conda-forge install docs

### DIFF
--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -45,6 +45,15 @@ For plotting
 Instructions
 ------------
 
+You can install Salem via `conda-forge`_::
+
+    conda config --add channels conda-forge
+    conda install salem
+
+or pip::
+
+    pip install salem
+
 The very best (unique?) way to install Salem without too much hassle is to
 install its dependencies with `conda`_ and `conda-forge`_::
 
@@ -59,7 +68,6 @@ If you want to install the latest master::
 
     pip install git+https://github.com/fmaussion/salem.git
 
-.. _conda: http://conda.pydata.org/docs/intro.html
 .. _conda-forge: http://conda-forge.github.io
 
 .. warning::


### PR DESCRIPTION
https://salem.readthedocs.io/en/stable/installing.html#instructions

Says "Currently, Salem can only be installed via pip". It was added to conda-forge a while ago: https://github.com/conda-forge/salem-feedstock