### PR TITLE
Small changes that allow for the usage of the rotated pole COSMO data or similarly structured datasets

### DIFF
--- a/salem/sio.py
+++ b/salem/sio.py
@@ -280,84 +280,6 @@ def _lonlat_grid_from_dataset(ds):
                 x0y0=(lon[0], lat[0]))
     return gis.Grid(**args)
 
-def _rotated_grid_from_dataset(ds):
-    """ Seek for rotated pole grid.
-        Based on _salem_grid_from_dataset
-    """
-    #Insert little check here for COSMO data - needs to be extended for other rotated datasets
-    if 'rotated_pole' in list(ds.variables.keys()):
-        # get pyproj string
-        n_lon = 'grid_north_pole_longitude'
-        n_lat = 'grid_north_pole_latitude'
-        cen_lon = 'north_pole_grid_longitude'
-        # Since it seems to rely on Netcdf4
-        # Add here extended code for other rotated datasets that do not have rotated pole as var
-        try:
-            pole_longitude = ds['rotated_pole'].getncattr(n_lon)
-            pole_latitude = ds['rotated_pole'].getncattr(n_lat)
-            if 'cen_lon' in ds['rotated_pole'].ncattrs():
-                central_rotated_longitude = ds['rotated_pole'].getncattr(cen_lon)
-            else:
-                central_rotated_longitude = 0
-        except:
-            print("No attributes with the names {}, {} and {} found in the data.".format(n_lon, n_lat, cen_lon))
-
-        '''
-        automatic_proj = True
-        if automatic_proj:
-            # relies on cartopy to automatically determine proj string
-            import cartopy.crs as ccrs
-
-            crs = ccrs.RotatedPole(pole_longitude=pole_longitude, pole_latitude=pole_latitude,
-                                   central_rotated_longitude=central_rotated_longitude)
-            srs = crs.proj4_init
-        '''
-        srs = ('+ellps=WGS84 +proj=ob_tran +o_proj=latlon '
-               '+to_meter=0.0174532925199433 '
-               '+o_lon_p={o_lon_p} +o_lat_p={o_lat_p} +lon_0={lon_0} +no_defs')
-        params = {
-            'o_lon_p': central_rotated_longitude,
-            'o_lat_p': pole_latitude,
-            'lon_0': 180 + pole_longitude,
-        }
-        proj = srs.format(**params)
-
-    proj = gis.check_crs(proj)
-    if proj is None:
-        return None
-
-    # Rest can be copied from _salem_grid_from_dataset
-    # Do we have some standard names as variable?
-    vns = ds.variables.keys()
-    xc = utils.str_in_list(vns, utils.valid_names['x_dim'])
-    yc = utils.str_in_list(vns, utils.valid_names['y_dim'])
-
-    # Sometimes there are more than one coordinates, one of which might have
-    # more dims (e.g. lons in WRF files): take the first one with ndim = 1:
-    x = None
-    for xp in xc:
-        if len(ds.variables[xp].shape) == 1:
-            x = xp
-    y = None
-    for yp in yc:
-        if len(ds.variables[yp].shape) == 1:
-            y = yp
-    if (x is None) or (y is None):
-        return None
-
-    # OK, get it
-    x = ds.variables[x][:]
-    y = ds.variables[y][:]
-
-    # Make the grid
-    dx = x[1] - x[0]
-    dy = y[1] - y[0]
-    args = dict(nxny=(x.shape[0], y.shape[0]), proj=proj, dxdy=(dx, dy),
-                x0y0=(x[0], y[0]))
-
-    return gis.Grid(**args)
-
-
 
 def _salem_grid_from_dataset(ds):
     """Seek for coordinates that Salem might have created.
@@ -418,9 +340,6 @@ def grid_from_dataset(ds):
     out = _salem_grid_from_dataset(ds)
     if out is not None:
         return out
-
-    if 'rotated_pole' in list(ds.variables.keys()):
-        return _rotated_grid_from_dataset(ds)
 
     # maybe it's a WRF file?
     if hasattr(ds, 'MOAD_CEN_LAT') or hasattr(ds, 'PROJ_ENVI_STRING'):
@@ -1117,7 +1036,8 @@ def is_rotated_proj_working():
                       atol=1e-5).all()
 
 
-def open_metum_dataset(file, pole_longitude=None, pole_latitude=None, central_rotated_longitude=None, automatic_proj = False, **kwargs):
+def open_metum_dataset(file, pole_longitude=None, pole_latitude=None,
+                       central_rotated_longitude=0., **kwargs):
     """Wrapper to Met Office Unified Model files (experimental)
 
     This is needed because these files are a little messy.
@@ -1135,9 +1055,6 @@ def open_metum_dataset(file, pole_longitude=None, pole_latitude=None, central_ro
     central_rotated_longitude: optional
         Longitude rotation about the new pole, in degrees. Defaults to the one
         found in the file (if found) and 0 otherwise.
-    automatic_proj: optional
-        Use cartopy to automatically determine the proj4 string instead of manually creating it.
-        Defaults to False.
     **kwargs : optional
         Additional arguments passed on to ``xarray.open_dataset``.
 
@@ -1162,46 +1079,32 @@ def open_metum_dataset(file, pole_longitude=None, pole_latitude=None, central_ro
             ds[vn] = v.where(v <= 180, v - 360)
 
     # get pyproj string
-    if pole_longitude is None or pole_latitude is None or central_rotated_longitude is None:
+    if pole_longitude is None or pole_latitude is None:
         # search for specific attributes names
         n_lon = 'grid_north_pole_longitude'
         n_lat = 'grid_north_pole_latitude'
-        cen_lon = 'north_pole_grid_longitude'
         # first in dataset
         pole_longitude = ds.attrs.get(n_lon, None)
         pole_latitude = ds.attrs.get(n_lat, None)
-        central_rotated_longitude = ds.attrs.get(n_lat, None)
         # then as variable attribute
-        if pole_longitude is None or pole_latitude is None or central_rotated_longitude is None:
+        if pole_longitude is None or pole_latitude is None:
             for k, v in ds.variables.items():
                 if n_lon in v.attrs:
                     pole_longitude = v.attrs[n_lon]
                 if n_lat in v.attrs:
                     pole_latitude = v.attrs[n_lat]
-                if cen_lon in v.attrs:
-                    central_rotated_longitude = v.attrs[cen_lon]
-                else:
-                    central_rotated_longitude = 0 #defaults to zero
                 if pole_longitude is not None and pole_latitude is not None:
                     break
 
-    if automatic_proj:
-        # relies on cartopy to automatically determine proj string
-        import cartopy.crs as ccrs
-
-        crs = ccrs.RotatedPole(pole_longitude=pole_longitude, pole_latitude=pole_latitude,
-                               central_rotated_longitude=central_rotated_longitude)
-        srs = crs.proj4_init
-    else:
-        srs = ('+ellps=WGS84 +proj=ob_tran +o_proj=latlon '
-               '+to_meter=0.0174532925199433 '
-               '+o_lon_p={o_lon_p} +o_lat_p={o_lat_p} +lon_0={lon_0} +no_defs')
-        params = {
-            'o_lon_p': central_rotated_longitude,
-            'o_lat_p': pole_latitude,
-            'lon_0': 180 + pole_longitude,
-        }
-        srs = srs.format(**params)
+    srs = ('+ellps=WGS84 +proj=ob_tran +o_proj=latlon '
+           '+to_meter=0.0174532925199433 '
+           '+o_lon_p={o_lon_p} +o_lat_p={o_lat_p} +lon_0={lon_0} +no_defs')
+    params = {
+        'o_lon_p': central_rotated_longitude,
+        'o_lat_p': pole_latitude,
+        'lon_0': 180 + pole_longitude,
+    }
+    srs = srs.format(**params)
 
     # add pyproj string everywhere
     ds.attrs['pyproj_srs'] = srs

--- a/salem/sio.py
+++ b/salem/sio.py
@@ -280,6 +280,84 @@ def _lonlat_grid_from_dataset(ds):
                 x0y0=(lon[0], lat[0]))
     return gis.Grid(**args)
 
+def _rotated_grid_from_dataset(ds):
+    """ Seek for rotated pole grid.
+        Based on _salem_grid_from_dataset
+    """
+    #Insert little check here for COSMO data - needs to be extended for other rotated datasets
+    if 'rotated_pole' in list(ds.variables.keys()):
+        # get pyproj string
+        n_lon = 'grid_north_pole_longitude'
+        n_lat = 'grid_north_pole_latitude'
+        cen_lon = 'north_pole_grid_longitude'
+        # Since it seems to rely on Netcdf4
+        # Add here extended code for other rotated datasets that do not have rotated pole as var
+        try:
+            pole_longitude = ds['rotated_pole'].getncattr(n_lon)
+            pole_latitude = ds['rotated_pole'].getncattr(n_lat)
+            if 'cen_lon' in ds['rotated_pole'].ncattrs():
+                central_rotated_longitude = ds['rotated_pole'].getncattr(cen_lon)
+            else:
+                central_rotated_longitude = 0
+        except:
+            print("No attributes with the names {}, {} and {} found in the data.".format(n_lon, n_lat, cen_lon))
+
+        '''
+        automatic_proj = True
+        if automatic_proj:
+            # relies on cartopy to automatically determine proj string
+            import cartopy.crs as ccrs
+
+            crs = ccrs.RotatedPole(pole_longitude=pole_longitude, pole_latitude=pole_latitude,
+                                   central_rotated_longitude=central_rotated_longitude)
+            srs = crs.proj4_init
+        '''
+        srs = ('+ellps=WGS84 +proj=ob_tran +o_proj=latlon '
+               '+to_meter=0.0174532925199433 '
+               '+o_lon_p={o_lon_p} +o_lat_p={o_lat_p} +lon_0={lon_0} +no_defs')
+        params = {
+            'o_lon_p': central_rotated_longitude,
+            'o_lat_p': pole_latitude,
+            'lon_0': 180 + pole_longitude,
+        }
+        proj = srs.format(**params)
+
+    proj = gis.check_crs(proj)
+    if proj is None:
+        return None
+
+    # Rest can be copied from _salem_grid_from_dataset
+    # Do we have some standard names as variable?
+    vns = ds.variables.keys()
+    xc = utils.str_in_list(vns, utils.valid_names['x_dim'])
+    yc = utils.str_in_list(vns, utils.valid_names['y_dim'])
+
+    # Sometimes there are more than one coordinates, one of which might have
+    # more dims (e.g. lons in WRF files): take the first one with ndim = 1:
+    x = None
+    for xp in xc:
+        if len(ds.variables[xp].shape) == 1:
+            x = xp
+    y = None
+    for yp in yc:
+        if len(ds.variables[yp].shape) == 1:
+            y = yp
+    if (x is None) or (y is None):
+        return None
+
+    # OK, get it
+    x = ds.variables[x][:]
+    y = ds.variables[y][:]
+
+    # Make the grid
+    dx = x[1] - x[0]
+    dy = y[1] - y[0]
+    args = dict(nxny=(x.shape[0], y.shape[0]), proj=proj, dxdy=(dx, dy),
+                x0y0=(x[0], y[0]))
+
+    return gis.Grid(**args)
+
+
 
 def _salem_grid_from_dataset(ds):
     """Seek for coordinates that Salem might have created.
@@ -340,6 +418,9 @@ def grid_from_dataset(ds):
     out = _salem_grid_from_dataset(ds)
     if out is not None:
         return out
+
+    if 'rotated_pole' in list(ds.variables.keys()):
+        return _rotated_grid_from_dataset(ds)
 
     # maybe it's a WRF file?
     if hasattr(ds, 'MOAD_CEN_LAT') or hasattr(ds, 'PROJ_ENVI_STRING'):
@@ -1036,8 +1117,7 @@ def is_rotated_proj_working():
                       atol=1e-5).all()
 
 
-def open_metum_dataset(file, pole_longitude=None, pole_latitude=None,
-                       central_rotated_longitude=0., **kwargs):
+def open_metum_dataset(file, pole_longitude=None, pole_latitude=None, central_rotated_longitude=None, automatic_proj = False, **kwargs):
     """Wrapper to Met Office Unified Model files (experimental)
 
     This is needed because these files are a little messy.
@@ -1055,6 +1135,9 @@ def open_metum_dataset(file, pole_longitude=None, pole_latitude=None,
     central_rotated_longitude: optional
         Longitude rotation about the new pole, in degrees. Defaults to the one
         found in the file (if found) and 0 otherwise.
+    automatic_proj: optional
+        Use cartopy to automatically determine the proj4 string instead of manually creating it.
+        Defaults to False.
     **kwargs : optional
         Additional arguments passed on to ``xarray.open_dataset``.
 
@@ -1079,32 +1162,46 @@ def open_metum_dataset(file, pole_longitude=None, pole_latitude=None,
             ds[vn] = v.where(v <= 180, v - 360)
 
     # get pyproj string
-    if pole_longitude is None or pole_latitude is None:
+    if pole_longitude is None or pole_latitude is None or central_rotated_longitude is None:
         # search for specific attributes names
         n_lon = 'grid_north_pole_longitude'
         n_lat = 'grid_north_pole_latitude'
+        cen_lon = 'north_pole_grid_longitude'
         # first in dataset
         pole_longitude = ds.attrs.get(n_lon, None)
         pole_latitude = ds.attrs.get(n_lat, None)
+        central_rotated_longitude = ds.attrs.get(n_lat, None)
         # then as variable attribute
-        if pole_longitude is None or pole_latitude is None:
+        if pole_longitude is None or pole_latitude is None or central_rotated_longitude is None:
             for k, v in ds.variables.items():
                 if n_lon in v.attrs:
                     pole_longitude = v.attrs[n_lon]
                 if n_lat in v.attrs:
                     pole_latitude = v.attrs[n_lat]
+                if cen_lon in v.attrs:
+                    central_rotated_longitude = v.attrs[cen_lon]
+                else:
+                    central_rotated_longitude = 0 #defaults to zero
                 if pole_longitude is not None and pole_latitude is not None:
                     break
 
-    srs = ('+ellps=WGS84 +proj=ob_tran +o_proj=latlon '
-           '+to_meter=0.0174532925199433 '
-           '+o_lon_p={o_lon_p} +o_lat_p={o_lat_p} +lon_0={lon_0} +no_defs')
-    params = {
-        'o_lon_p': central_rotated_longitude,
-        'o_lat_p': pole_latitude,
-        'lon_0': 180 + pole_longitude,
-    }
-    srs = srs.format(**params)
+    if automatic_proj:
+        # relies on cartopy to automatically determine proj string
+        import cartopy.crs as ccrs
+
+        crs = ccrs.RotatedPole(pole_longitude=pole_longitude, pole_latitude=pole_latitude,
+                               central_rotated_longitude=central_rotated_longitude)
+        srs = crs.proj4_init
+    else:
+        srs = ('+ellps=WGS84 +proj=ob_tran +o_proj=latlon '
+               '+to_meter=0.0174532925199433 '
+               '+o_lon_p={o_lon_p} +o_lat_p={o_lat_p} +lon_0={lon_0} +no_defs')
+        params = {
+            'o_lon_p': central_rotated_longitude,
+            'o_lat_p': pole_latitude,
+            'lon_0': 180 + pole_longitude,
+        }
+        srs = srs.format(**params)
 
     # add pyproj string everywhere
     ds.attrs['pyproj_srs'] = srs

--- a/salem/sio.py
+++ b/salem/sio.py
@@ -285,47 +285,46 @@ def _rotated_grid_from_dataset(ds):
         Based on _salem_grid_from_dataset
     """
     #Insert little check here for COSMO data - needs to be extended for other rotated datasets
-    if 'rotated_pole' in list(ds.variables.keys()):
-        # get pyproj string
-        n_lon = 'grid_north_pole_longitude'
-        n_lat = 'grid_north_pole_latitude'
-        cen_lon = 'north_pole_grid_longitude'
-        # Since it seems to rely on Netcdf4
-        # Add here extended code for other rotated datasets that do not have rotated pole as var
-        try:
-            pole_longitude = ds['rotated_pole'].getncattr(n_lon)
-            pole_latitude = ds['rotated_pole'].getncattr(n_lat)
-            if 'cen_lon' in ds['rotated_pole'].ncattrs():
-                central_rotated_longitude = ds['rotated_pole'].getncattr(cen_lon)
-            else:
-                central_rotated_longitude = 0
-        except:
-            pole_longitude = ds.attrs.get(n_lon, None)
-            pole_latitude = ds.attrs.get(n_lat, None)
-            central_rotated_longitude = ds.attrs.get(cen_lon, None)
-            # then as variable attribute
-            if pole_longitude is None or pole_latitude is None or central_rotated_longitude is None:
-                for k, v in ds.variables.items():
-                    if n_lon in v.attrs:
-                        pole_longitude = v.attrs[n_lon]
-                    if n_lat in v.attrs:
-                        pole_latitude = v.attrs[n_lat]
-                    if cen_lon in v.attrs:
-                        central_rotated_longitude = v.attrs[cen_lon]
-                    else:
-                        central_rotated_longitude = 0 #defaults to zero
-                    if pole_longitude is not None and pole_latitude is not None:
-                        break        
+    # get pyproj string
+    n_lon = 'grid_north_pole_longitude'
+    n_lat = 'grid_north_pole_latitude'
+    cen_lon = 'north_pole_grid_longitude'
+    # Since it seems to rely on Netcdf4
+    # Add here extended code for other rotated datasets that do not have rotated pole as var
+    try:
+        pole_longitude = ds['rotated_pole'].getncattr(n_lon)
+        pole_latitude = ds['rotated_pole'].getncattr(n_lat)
+        if 'cen_lon' in ds['rotated_pole'].ncattrs():
+            central_rotated_longitude = ds['rotated_pole'].getncattr(cen_lon)
+        else:
+            central_rotated_longitude = 0
+    except:
+        pole_longitude = ds.attrs.get(n_lon, None)
+        pole_latitude = ds.attrs.get(n_lat, None)
+        central_rotated_longitude = ds.attrs.get(cen_lon, None)
+        # then as variable attribute
+        if pole_longitude is None or pole_latitude is None or central_rotated_longitude is None:
+            for k, v in ds.variables.items():
+                if n_lon in v.attrs:
+                    pole_longitude = v.attrs[n_lon]
+                if n_lat in v.attrs:
+                    pole_latitude = v.attrs[n_lat]
+                if cen_lon in v.attrs:
+                    central_rotated_longitude = v.attrs[cen_lon]
+                else:
+                    central_rotated_longitude = 0 #defaults to zero
+                if pole_longitude is not None and pole_latitude is not None:
+                    break        
         
-        srs = ('+ellps=WGS84 +proj=ob_tran +o_proj=latlon '
-               '+to_meter=0.0174532925199433 '
-               '+o_lon_p={o_lon_p} +o_lat_p={o_lat_p} +lon_0={lon_0} +no_defs')
-        params = {
-            'o_lon_p': central_rotated_longitude,
-            'o_lat_p': pole_latitude,
-            'lon_0': 180 + pole_longitude,
-        }
-        proj = srs.format(**params)
+    srs = ('+ellps=WGS84 +proj=ob_tran +o_proj=latlon '
+           '+to_meter=0.0174532925199433 '
+           '+o_lon_p={o_lon_p} +o_lat_p={o_lat_p} +lon_0={lon_0} +no_defs')
+    params = {
+        'o_lon_p': central_rotated_longitude,
+        'o_lat_p': pole_latitude,
+        'lon_0': 180 + pole_longitude,
+    }
+    proj = srs.format(**params)
 
     proj = gis.check_crs(proj)
     if proj is None:

--- a/salem/utils.py
+++ b/salem/utils.py
@@ -97,10 +97,10 @@ valid_names = dict()
 valid_names['x_dim'] = ['west_east', 'lon', 'longitude', 'longitudes', 'lons',
                         'xlong', 'xlong_m', 'dimlon', 'x', 'lon_3', 'long',
                         'phony_dim_0', 'eastings', 'easting', 'nlon', 'nlong',
-                        'grid_longitude_t', 'rlon']
+                        'grid_longitude_t']
 valid_names['y_dim'] = ['south_north', 'lat', 'latitude', 'latitudes', 'lats',
                         'xlat', 'xlat_m', 'dimlat', 'y','lat_3', 'phony_dim_1',
-                        'northings', 'northing', 'nlat', 'grid_latitude_t', 'rlat']
+                        'northings', 'northing', 'nlat', 'grid_latitude_t']
 valid_names['z_dim'] = ['levelist','level', 'pressure', 'press', 'zlevel', 'z',
                         'bottom_top']
 valid_names['t_dim'] = ['time', 'times', 'xtime']

--- a/salem/utils.py
+++ b/salem/utils.py
@@ -97,10 +97,10 @@ valid_names = dict()
 valid_names['x_dim'] = ['west_east', 'lon', 'longitude', 'longitudes', 'lons',
                         'xlong', 'xlong_m', 'dimlon', 'x', 'lon_3', 'long',
                         'phony_dim_0', 'eastings', 'easting', 'nlon', 'nlong',
-                        'grid_longitude_t']
+                        'grid_longitude_t', 'rlon']
 valid_names['y_dim'] = ['south_north', 'lat', 'latitude', 'latitudes', 'lats',
                         'xlat', 'xlat_m', 'dimlat', 'y','lat_3', 'phony_dim_1',
-                        'northings', 'northing', 'nlat', 'grid_latitude_t']
+                        'northings', 'northing', 'nlat', 'grid_latitude_t', 'rlat']
 valid_names['z_dim'] = ['levelist','level', 'pressure', 'press', 'zlevel', 'z',
                         'bottom_top']
 valid_names['t_dim'] = ['time', 'times', 'xtime']


### PR DESCRIPTION
These are the small changes I had to implement to evaluate COSMO-CLM data which comes with a rotated pole grid. The changes are very specific to that dataset and might need some extension to be valid for other rotated pole datasets. 

Namely I added rlat and rlon to the known dimension names and built upon the open_metum_dataset function and the _salem_grid_from_dataset function to allow the usage of GeoNetcdf and open_metum_dataset and find and assign the correct pyproj string. 

Note: One could rename the open_metum_dataset to something like open_rotatedpole_dataset since it should work on metum and COSMO datasets. 



