### PR TITLE
add map_proj = 6 (Lat-lon)

### DIFF
--- a/salem/sio.py
+++ b/salem/sio.py
@@ -140,6 +140,12 @@ def _wrf_grid_from_dataset(ds):
         if ds.PROJ_NAME in ['Lambert Conformal Conic',
                             'WRF Lambert Conformal']:
             proj_id = 1
+        elif ds.PROJ_NAME in ['polar stereographic']:
+            proj_id = 2
+        elif ds.PROJ_NAME in ['mercator']:
+            proj_id = 3
+        elif ds.PROJ_NAME in ['LatLon', 'lat-lon', 'LatLong']:
+            proj_id = 6
         else:
             proj_id = 99  # pragma: no cover
     else:
@@ -170,6 +176,12 @@ def _wrf_grid_from_dataset(ds):
         # Mercator
         p4 = '+proj=merc +lat_ts={lat_1} ' \
              '+lon_0={center_lon} ' \
+             '+x_0=0 +y_0=0 +a=6370000 +b=6370000'
+        p4 = p4.format(**pargs)
+    elif proj_id == 6:
+        # Lat-long
+        p4 = '+proj=eqc ' \
+             '+lon_0={lon_0} ' \
              '+x_0=0 +y_0=0 +a=6370000 +b=6370000'
         p4 = p4.format(**pargs)
     else:

--- a/salem/wrftools.py
+++ b/salem/wrftools.py
@@ -722,6 +722,11 @@ def geogrid_simulator(fpath, do_maps=True, map_kwargs=None):
         pwrf = '+proj=stere +lat_ts={lat_1} +lat_0=90.0 +lon_0={lon_0} ' \
                '+x_0=0 +y_0=0 +a=6370000 +b=6370000'
         pwrf = pwrf.format(**pargs)
+    #TODO: not sure how map_proj is converted to this string instead of int?
+    elif map_proj == 'LATLON':
+        pwrf = '+proj=eqc +lon_0={lon_0} ' \
+               '+x_0=0 +y_0=0 +a=6370000 +b=6370000'
+        pwrf = pwrf.format(**pargs)
     else:
         raise NotImplementedError('WRF proj not implemented yet: '
                                   '{}'.format(map_proj))


### PR DESCRIPTION
 - Addresses #199 
 - Allows to map WRF information that have MAP_PROJ = 6 (Lat-Lon)
- No test has been added.
- I also added this same reprojection information in `wrftools.geogrid_simulator()`. Also this is not tested?

A small test file is available here: [geo_em.d04_map_proj6.zip](https://github.com/fmaussion/salem/files/8877612/geo_em.d04_map_proj6.zip)

```
import salem
ifile = "geo_em.d04_map_proj6.nc"
ds = salem.open_xr_dataset(ifile)
ds.salem.quick_map('LU_INDEX')
```

