### PR TITLE
Solve issue of opening WRF file with no description (#219)

### DIFF
--- a/salem/wrftools.py
+++ b/salem/wrftools.py
@@ -63,7 +63,12 @@ class Unstaggerer(object):
         self.ncvar = ncvar
 
         # Attributes
-        self.description = ncvar.description
+        # if no description is provided, gives empty string
+        try:
+            self.description = ncvar.description
+        except:
+            self.description = ''
+            
         self.units = ncvar.units
         # Replace the dimension name
         dims = list(ncvar.dimensions)

--- a/salem/wrftools.py
+++ b/salem/wrftools.py
@@ -66,6 +66,7 @@ class Unstaggerer(object):
         try:
             self.description = ncvar.description
         except AttributeError:
+            # This attr might be needed later
             self.description = ''
             
         self.units = ncvar.units

--- a/salem/wrftools.py
+++ b/salem/wrftools.py
@@ -63,10 +63,9 @@ class Unstaggerer(object):
         self.ncvar = ncvar
 
         # Attributes
-        # if no description is provided, gives empty string
         try:
             self.description = ncvar.description
-        except:
+        except AttributeError:
             self.description = ''
             
         self.units = ncvar.units


### PR DESCRIPTION
Edit Unstaggerd __init__. If no description in input WRF file, set description as an empty string. Solve issue #219 
