### PR TITLE
Use center_grid when opening tiff-file

### DIFF
--- a/salem/sio.py
+++ b/salem/sio.py
@@ -922,8 +922,8 @@ def open_xr_dataset(file):
         geo = GeoTiff(file)
         # TODO: currently everything is loaded in memory (baaad)
         da = xr.DataArray(geo.get_vardata(),
-                          coords={'x': geo.grid.x_coord,
-                                  'y': geo.grid.y_coord},
+                          coords={'x': geo.grid.center_grid.x_coord,
+                                  'y': geo.grid.center_grid.y_coord},
                           dims=['y', 'x'])
         ds = xr.Dataset()
         ds.attrs['pyproj_srs'] = geo.grid.proj.srs

--- a/salem/tests/test_datasets.py
+++ b/salem/tests/test_datasets.py
@@ -211,8 +211,8 @@ class TestGeotiff(unittest.TestCase):
         np.testing.assert_array_equal(ref.shape, (gos.salem.grid.ny, gos.salem.grid.nx))
         np.testing.assert_array_equal(ref.shape, totest.shape)
         np.testing.assert_array_equal(ref, totest)
-        rlon, rlat = geo.grid.ll_coordinates
-        tlon, tlat = go.salem.grid.ll_coordinates
+        rlon, rlat = geo.grid.center_grid.ll_coordinates
+        tlon, tlat = go.salem.grid.center_grid.ll_coordinates
         assert_allclose(rlon, tlon)
         assert_allclose(rlat, tlat)
 


### PR DESCRIPTION
There seems to be a bug when opening a tiff-file with `ds=salem.open_xr_dataset(tiff_path)` and calling `ds.salem.grid` afterwards. When opening the tiff-file the resulting grid is defined with corner-reference here https://github.com/fmaussion/salem/blob/master/salem/datasets.py#L288, but when you call `ds.salem.grid` it is assumed that the coordinates are with center-reference here https://github.com/fmaussion/salem/blob/master/salem/sio.py#L425 and here https://github.com/fmaussion/salem/blob/master/salem/sio.py#L333.

Related to https://github.com/OGGM/oggm/pull/1682

- [ ] closes #xxxx
 - [ ] tests added / passed
 - [ ] passes ``git diff upstream/master | flake8 --diff``
 - [ ] whatsnew entry
