### PR TITLE
fix(metadata): explicitly set version

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -6,6 +6,7 @@ What's New
 v0.3.x (Unreleased)
 -------------------
 
+- fix a bug in which ```salem.__version__``` would not show the correct version
 
 v0.3.11 (12 July 2024)
 ----------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [metadata]
 name = salem
+version = 0.3.11
 description = Geoscientific data I/O and map projections
 long_description = file: README.rst
 long_description_content_type = text/x-rst; charset=UTF-8


### PR DESCRIPTION
salem.__version__ now correctly reflects the version of the package.

 - [ ] closes #xxxx
 - [ ] tests added / passed
 - [x] passes ``git diff upstream/master | flake8 --diff``
 - [x] whatsnew entry

salem.utils reads package metadata, but version number was not explicitly set. This resulted in version numbering v0.1+githash for regardless of real release number.